### PR TITLE
On demand target generation

### DIFF
--- a/ipCalculation.go
+++ b/ipCalculation.go
@@ -1,0 +1,106 @@
+// This is a (probably simplified) Go implementation of ZMap's
+// ip calculation sharding algorithm used to pseudo-randomize
+// an IP address space without performing a precalculation of
+// all IPs and making sure that every IP is returned exactly once
+
+package main
+
+import (
+	"math/big"
+	"math/rand"
+)
+
+type cyclicGroup struct {
+	prime           uint64
+	knownPrimroot   uint64
+	primeFactors    []uint64
+	numPrimeFactors uint64
+}
+
+type cycle struct {
+	group     *cyclicGroup
+	generator uint64
+	order     uint64
+	offset    uint32
+}
+
+var cyclicGroups [5]cyclicGroup
+
+func init() {
+	cyclicGroups = [5]cyclicGroup{
+		{257, 3, []uint64{2}, 1},                           // 2^8 + 1
+		{65537, 3, []uint64{2}, 1},                         // 2^16 + 1
+		{16777259, 2, []uint64{2, 23, 103, 3541}, 4},       // 2^24 + 43
+		{268435459, 2, []uint64{2, 3, 19, 87211}, 4},       // 2^28 + 3
+		{4294967311, 3, []uint64{2, 3, 5, 131, 364289}, 5}} // 2^32 + 15
+}
+
+func isCoprime(check uint64, group *cyclicGroup) bool {
+	for i := uint64(0); i < group.numPrimeFactors; i++ {
+		if (group.primeFactors[i] > check) &&
+			(group.primeFactors[i]%check == 0) {
+			return false
+		} else if (group.primeFactors[i] < check) &&
+			(check%group.primeFactors[i] == 0) {
+			return false
+		} else if group.primeFactors[i] == check {
+			return false
+		}
+	}
+	return true
+}
+
+func findPrimroot(group *cyclicGroup, seed int64) uint32 {
+	rand.Seed(seed)
+	candidate := (rand.Uint64() & 0xFFFFFFFF) % group.prime
+	if candidate == 0 {
+		candidate++
+	}
+	for isCoprime(candidate, group) != true {
+		candidate++
+		if candidate >= group.prime {
+			candidate = 1
+		}
+	}
+	return uint32(isomorphism(candidate, group))
+}
+
+func isomorphism(additiveElt uint64, multGroup *cyclicGroup) uint64 {
+	if !(additiveElt < multGroup.prime) {
+		panic("Assertion failed")
+	}
+	var base, power, prime, primroot big.Int
+	base.SetUint64(multGroup.knownPrimroot)
+	power.SetUint64(additiveElt)
+	prime.SetUint64(multGroup.prime)
+	primroot.Exp(&base, &power, &prime)
+	return primroot.Uint64()
+}
+
+func getGroup(minSize uint64) *cyclicGroup {
+	for i := 0; i < len(cyclicGroups); i++ {
+		if cyclicGroups[i].prime > minSize {
+			return &cyclicGroups[i]
+		}
+	}
+	panic("No cyclic group found with prime large enough. This is impossible.")
+}
+
+func makeCycle(group *cyclicGroup, seed int64) cycle {
+	generator := findPrimroot(group, seed)
+	offset := (rand.Uint64() & 0xFFFFFFFF) % group.prime
+	return cycle{group, uint64(generator), group.prime - 1, uint32(offset)}
+}
+
+func first(c *cycle) uint64 {
+	var generator, exponentBegin, prime, start big.Int
+	generator.SetUint64(c.generator)
+	prime.SetUint64(c.group.prime)
+	exponentBegin.SetUint64(c.order)
+	start.Exp(&generator, &exponentBegin, &prime)
+	return start.Uint64()
+}
+
+func next(c *cycle, current *uint64) {
+	*current = (*current * c.generator) % c.group.prime
+}

--- a/main.go
+++ b/main.go
@@ -37,11 +37,11 @@ func main() {
 // This function fills the workQueue channel with tcinstances that are scanned
 // It also tracks process and reports status from time to time
 func fillQueue(workQueue chan<- TcInstance) {
-	numTargets := len(scannerConfig.targetRange) * len(scannerConfig.ports)
-	progress := 0
-	tenths := 1
+	numTargets := scannerConfig.targetSize * uint64(len(scannerConfig.ports))
+	progress := uint64(0)
+	tenths := uint64(1)
 	for {
-		element, ok := <-scannerConfig.targetRange
+		element, ok := <-scannerConfig.targetChan
 		if !ok {
 			break
 		}

--- a/main.go
+++ b/main.go
@@ -40,7 +40,12 @@ func fillQueue(workQueue chan<- TcInstance) {
 	numTargets := len(scannerConfig.targetRange) * len(scannerConfig.ports)
 	progress := 0
 	tenths := 1
-	for _, element := range scannerConfig.targetRange {
+	for {
+		element, ok := <-scannerConfig.targetRange
+		if !ok {
+			break
+		}
+		prettyPrintLn(debug, fmt.Sprintf("Now sending to %v\n", element))
 		for _, port := range scannerConfig.ports {
 			if progress > tenths*(numTargets/10) {
 				prettyPrintLn(info, fmt.Sprintf("~%d0%% (%d/%d)", tenths, progress, numTargets))


### PR DESCRIPTION
This PR introduces on-demand target address generation and a small bug fix.

### On demand target generation 

In case randomization is disabled, the underlying cidr module is sequentially asked for ip addresses until we are done.
In case randomization is enabled (default), the algorithm introduced by ZMap is used. Basically it choses a random generator of a cyclic group to then sequentially generate all elements of a group in a pseudo-random order. The underlying cidr module is then used to map the n-th element of the group to the respective IP address.
Currently, there is only one goroutine performing address generation and passing them through a channel and I think there is no need for more in the future.

### IP parsing bugfix

During testing I found out that the parsing of IP addresses is fragile in some scenarios; I also recognized that go already brings functions for such parsing tasks, so removing my code and switching to golang builtins simplifies the code and improves the stability